### PR TITLE
Update unit tests for MongoStorage with motor and pymongo support

### DIFF
--- a/CHANGES/1234.feature.rst
+++ b/CHANGES/1234.feature.rst
@@ -1,0 +1,1 @@
+Added tests for `motor`'s `AsyncIOMotorClient` and `pymongo`'s `AsyncMongoClient` in `tests/test_fsm/storage/test_mongo.py` to cover setting and getting state and data using both clients.

--- a/tests/test_fsm/storage/test_mongo.py
+++ b/tests/test_fsm/storage/test_mongo.py
@@ -164,3 +164,51 @@ class TestStateAndDataDoNotAffectEachOther:
 )
 def test_resolve_state(value, result, mongo_storage: MongoStorage):
     assert mongo_storage.resolve_state(value) == result
+
+
+# Tests for motor's AsyncIOMotorClient
+@pytest.mark.asyncio
+async def test_motor_asyncio_client(mongo_server):
+    from motor.motor_asyncio import AsyncIOMotorClient
+
+    client = AsyncIOMotorClient(mongo_server)
+    storage = MongoStorage(client=client)
+    storage_key = StorageKey(chat_id=CHAT_ID, user_id=USER_ID)
+
+    await storage.set_state(storage_key, "test")
+    assert await storage.get_state(storage_key) == "test"
+
+    await storage.set_data(storage_key, {"key": "value"})
+    assert await storage.get_data(storage_key) == {"key": "value"}
+
+    await storage.set_state(storage_key, None)
+    assert await storage.get_state(storage_key) is None
+
+    await storage.set_data(storage_key, {})
+    assert await storage.get_data(storage_key) == {}
+
+    await storage.close()
+
+
+# Tests for pymongo's AsyncMongoClient
+@pytest.mark.asyncio
+async def test_pymongo_async_client(mongo_server):
+    from pymongo.asynchronous.mongo_client import AsyncMongoClient
+
+    client = AsyncMongoClient(mongo_server)
+    storage = MongoStorage(client=client)
+    storage_key = StorageKey(chat_id=CHAT_ID, user_id=USER_ID)
+
+    await storage.set_state(storage_key, "test")
+    assert await storage.get_state(storage_key) == "test"
+
+    await storage.set_data(storage_key, {"key": "value"})
+    assert await storage.get_data(storage_key) == {"key": "value"}
+
+    await storage.set_state(storage_key, None)
+    assert await storage.get_state(storage_key) is None
+
+    await storage.set_data(storage_key, {})
+    assert await storage.get_data(storage_key) == {}
+
+    await storage.close()

--- a/tests/test_fsm/storage/test_storages.py
+++ b/tests/test_fsm/storage/test_storages.py
@@ -1,6 +1,7 @@
 import pytest
 
 from aiogram.fsm.storage.base import BaseStorage, StorageKey
+from aiogram.fsm.storage.mongo import MongoStorage
 
 
 @pytest.mark.parametrize(
@@ -65,3 +66,49 @@ class TestStorages:
             "foo": "bar",
             "baz": "test",
         }
+
+
+@pytest.mark.asyncio
+async def test_motor_asyncio_client(mongo_server):
+    from motor.motor_asyncio import AsyncIOMotorClient
+
+    client = AsyncIOMotorClient(mongo_server)
+    storage = MongoStorage(client=client)
+    storage_key = StorageKey(chat_id=CHAT_ID, user_id=USER_ID)
+
+    await storage.set_state(storage_key, "test")
+    assert await storage.get_state(storage_key) == "test"
+
+    await storage.set_data(storage_key, {"key": "value"})
+    assert await storage.get_data(storage_key) == {"key": "value"}
+
+    await storage.set_state(storage_key, None)
+    assert await storage.get_state(storage_key) is None
+
+    await storage.set_data(storage_key, {})
+    assert await storage.get_data(storage_key) == {}
+
+    await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_pymongo_async_client(mongo_server):
+    from pymongo.asynchronous.mongo_client import AsyncMongoClient
+
+    client = AsyncMongoClient(mongo_server)
+    storage = MongoStorage(client=client)
+    storage_key = StorageKey(chat_id=CHAT_ID, user_id=USER_ID)
+
+    await storage.set_state(storage_key, "test")
+    assert await storage.get_state(storage_key) == "test"
+
+    await storage.set_data(storage_key, {"key": "value"})
+    assert await storage.get_data(storage_key) == {"key": "value"}
+
+    await storage.set_state(storage_key, None)
+    assert await storage.get_state(storage_key) is None
+
+    await storage.set_data(storage_key, {})
+    assert await storage.get_data(storage_key) == {}
+
+    await storage.close()


### PR DESCRIPTION
Add unit tests for `motor`'s `AsyncIOMotorClient` and `pymongo`'s `AsyncMongoClient` in `MongoStorage`.

* **tests/test_fsm/storage/test_mongo.py**
  - Add tests for `motor`'s `AsyncIOMotorClient`
  - Add tests for `pymongo`'s `AsyncMongoClient`

* **tests/test_fsm/storage/test_storages.py**
  - Add specific tests for `motor` client in `MongoStorage`
  - Add specific tests for `pymongo` client in `MongoStorage`

